### PR TITLE
CELDEV-1076 - move templates and scripts from celements-web and structDataEditor

### DIFF
--- a/RichText-component/src/main/java/com/celements/tinymce4/RteTinyMce4.java
+++ b/RichText-component/src/main/java/com/celements/tinymce4/RteTinyMce4.java
@@ -41,7 +41,7 @@ public class RteTinyMce4 implements RteImplementation {
     return ImmutableList.of(
         ":celRTE/4.9.11/tinymce.min.js",
         ":celRTE/4.9.11/plugins/compat3x/plugin.min.js",
-        ":structEditJS/tinyMCE4/loadTinyMCE-async.js");
+        ":celRteJS/tinyMCE4/loadTinyMCE-async.js");
   }
 
 }

--- a/RichText-web-module/src/main/webapp/resources/celJS/celTabMenu/loadTinyMCE-async.js
+++ b/RichText-web-module/src/main/webapp/resources/celJS/celTabMenu/loadTinyMCE-async.js
@@ -1,0 +1,164 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+(function(window, undefined) {
+  "use strict";
+
+  var getAllEditorBodyClasses = function(tinyConfigObj) {
+    var generalBodyClasses = tinyConfigObj["body_class"];
+    var editorSelector = tinyConfigObj["editor_selector"];
+    var bodyClassArray = [];
+    $$('.' + editorSelector).each(function(textareaElem) {
+      var elemClasses = [];
+      $w(textareaElem.className).each(function(cssClassName) {
+        if (cssClassName.startsWith('celEditorBody_')) {
+          elemClasses.push(cssClassName);
+        }
+      });
+      var elemBodyClasses = elemClasses.join(' ') + ' ' + generalBodyClasses;
+      bodyClassArray.push(textareaElem.id + "=" + elemBodyClasses.strip());
+    });
+    return bodyClassArray;
+  };
+
+  var tinyConfigLoaded = false;
+  var editorCounter = 0;
+
+  var initCelRTE = function() {
+    console.log('initCelRTE: start');
+    if(!!window.MSStream && (navigator.userAgent.indexOf("MSIE") < 0)) { // if is IE11
+      alert('Der RichText Editor ist zur Zeit nicht für den Internet Explorer 11 verfügbar. Bitte verwenden Sie einen unterstützten Browser (Chrome, FireFox, Safari, IE10, IE9 oder IE8).');
+      return;
+    }
+    var params = {
+        xpage : 'celements_ajax',
+        ajax_mode : 'TinyConfig'
+     };
+    var hrefSearch = window.location.search;
+    var templateRegEx = new RegExp('^(\\?|(.*&)+)?template=([^=&]*).*$');
+    if (hrefSearch.match(templateRegEx)) {
+      params['template'] = window.location.search.replace(templateRegEx, '$3');
+    }
+    console.log('initCelRTE: before Ajax tinymce');
+    new Ajax.Request(getCelHost(), {
+      method: 'post',
+      parameters: params,
+      onSuccess: function(transport) {
+        var tinyConfigJSON = transport.responseText.replace(/\n/g,' ');
+        if (tinyConfigJSON.isJSON()) {
+          window.tinymce.dom.Event.domLoaded = true;
+          var tinyConfigObj = tinyConfigJSON.evalJSON();
+          tinyConfigObj["body_class"] = getAllEditorBodyClasses(tinyConfigObj).join(',');
+          tinyConfigObj["setup"] = celSetupTinyMCE;
+         console.log('initCelRTE: tinymce.init');
+         tinymce.init(tinyConfigObj);
+         tinyConfigLoaded = true;
+          console.debug('initCelRTE: tinymce.init finished');
+        } else {
+          console.error('TinyConfig is no json!', tinyConfigJSON);
+        }
+      }
+    });
+  };
+  
+  var celSetupTinyMCE = function(editor) {
+    console.log('celSetupTinyMCE start');
+    editor.onInit.add(celFinishTinyMCEStart);
+    console.log('celSetupTinyMCE finish');
+  };
+
+  var celFinishTinyMCEStart = function() {
+    try {
+      console.log('celFinishTinyMCEStart: start');
+      $$('body')[0].fire('celRTE:finishedInit');
+      console.log('celFinishTinyMCEStart: finish');
+    } catch (exp) {
+      console.error('celFinishTinyMCEStart failed', exp);
+    }
+  };
+
+  var lazyLoadTinyMCEforTab = function(event) {
+    try {
+      var tabBodyId = event.memo.newTabBodyId;
+      if (tinyConfigLoaded) {
+        getUninitializedMceEditors(tabBodyId).each(function(editorAreaId) {
+          console.log('lazyLoadTinyMCEforTab: mceAddControl for editorArea ', editorAreaId,
+              tabBodyId);
+          tinymce.execCommand("mceAddControl", false, editorAreaId);
+        });
+        console.log('lazyLoadTinyMCEforTab: finish', tabBodyId);
+      } else {
+        console.log('lazyLoadTinyMCEforTab: skip mceAddControl because tinyConfig not yet loaded.',
+            tabBodyId);
+      }
+    } catch (exp) {
+      console.error("lazyLoadTinyMCEforTab failed. ", exp);
+    }
+  };
+
+  var getUninitializedMceEditors = function(mceParentElem) {
+    console.log('getUninitializedMceEditors: start ', mceParentElem);
+    var mceEditorsToInit = new Array();
+    $(mceParentElem).select('textarea.mceEditor').each(function(editorArea) {
+      if (!editorArea.id) {
+        editorArea.writeAttribute('id', editorArea.name + 'Editor' + (++editorCounter));
+      }
+      var notInitialized = !tinymce.getInstanceById(editorArea.id);
+      console.log('getUninitializedMceEditors: found new editorArea ', editorArea.id,
+          notInitialized);
+      if (notInitialized) {
+        mceEditorsToInit.push(editorArea.id);
+      }
+    });
+    console.log('getUninitializedMceEditors: returns ', mceParentElem, mceEditorsToInit);
+    return mceEditorsToInit;
+  };
+
+  var delayedEditorOpeningHandler = function(event) {
+    console.log('delayedEditorOpeningHandler: start ', event.memo);
+    var mceParentElem = event.memo.tabBodyId || "tabMenuPanel";
+    var mceEditorAreaAvailable = (getUninitializedMceEditors(mceParentElem).size() > 0);
+    if (mceEditorAreaAvailable) {
+      console.debug('delayedEditorOpeningHandler: stopping display event');
+      event.stop();
+      $$('body')[0].observe('celRTE:finishedInit', function() {
+        console.debug('delayedEditorOpeningHandler: start display effect');
+        event.memo.effect.start();
+      });
+    }
+  };
+  
+  var initCelRTEListener = function() {
+    console.log('initCelRTEListener: before initCelRTE');
+    initCelRTE();
+  };
+
+  $j(document).ready(function() {
+    console.log("tinymce: register document ready...");
+    if ($('tabMenuPanel')) {
+      $('tabMenuPanel').observe('tabedit:finishedLoadingDisplayNow',
+          delayedEditorOpeningHandler);
+      $('tabMenuPanel').observe('tabedit:tabLoadingFinished', lazyLoadTinyMCEforTab);
+      console.log('loadTinyMCE-async on ready: before register initCelRTEListener');
+      getCelementsTabEditor().addAfterInitListener(initCelRTEListener);
+    }
+  });
+  
+})(window);

--- a/RichText-web-module/src/main/webapp/resources/celRteJS/tinyMCE4/loadTinyMCE-async.js
+++ b/RichText-web-module/src/main/webapp/resources/celRteJS/tinyMCE4/loadTinyMCE-async.js
@@ -1,0 +1,166 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+(function(window, undefined) {
+  "use strict";
+  
+  var tinyConfigLoaded = false;
+  var editorCounter = 0;
+
+  var initCelRTE4 = function() {
+    console.log('initCelRTE4: start');
+    var params = {
+        xpage : 'celements_ajax',
+        ajax_mode : 'tinymce/Tiny4Config'
+     };
+    var hrefSearch = window.location.search;
+    var templateRegEx = new RegExp('^(\\?|(.*&)+)?template=([^=&]*).*$');
+    if (hrefSearch.match(templateRegEx)) {
+      params['template'] = unescape(window.location.search.replace(templateRegEx, '$3'));
+    }
+    console.log('initCelRTE4: before Ajax tinymce');
+    new Ajax.Request(getCelHost(), {
+      method: 'post',
+      parameters: params,
+      onSuccess: function(transport) {
+        var tinyConfigJSON = transport.responseText;
+        console.log('tinymce4 config loaded: starting tiny');
+        if (tinyConfigJSON.isJSON()) {
+          var tinyConfigObj = tinyConfigJSON.evalJSON();
+          tinyConfigObj["setup"] = celSetupTinyMCE;
+          console.debug('initCelRTE4: tinymce.init');
+          tinymce.init(tinyConfigObj);
+          tinyConfigLoaded = true;
+          console.debug('initCelRTE4: tinymce.init finished');
+        } else {
+          console.error('TinyConfig is no json!', tinyConfigJSON);
+        }
+      }
+    });
+  };
+  
+  var celSetupTinyMCE = function(editor) {
+    console.log('celSetupTinyMCE start');
+    editor.on('init', celFinishTinyMCEStart);
+    console.log('celSetupTinyMCE finish');
+  };
+
+  /**
+   * loading in struct layout editor
+   **/
+  (function(structManager){
+    console.log('loadTinyMCE async: start');
+    if (structManager) {
+      if (!structManager.isStartFinished()) {
+        console.log('structEditorManager not initialized: register for finishLoading');
+        structManager.celStopObserving('structEdit:finishedLoading', initCelRTE4);
+        structManager.celObserve('structEdit:finishedLoading', initCelRTE4);
+      } else {
+        console.log('structEditorManager already initialized: initCelRTE4');
+        initCelRTE4();
+      }
+    } else {
+      console.warn('No struct editor manager found -> Failed to initialize tinymce4.');
+    }
+    console.log('loadTinyMCE async: end');
+  })(window.celStructEditorManager);
+
+  /**
+   * loading in overlay TabEditor
+   **/
+  var celFinishTinyMCEStart = function(event) {
+    try {
+      const editor = event.target;
+      console.debug('celFinishTinyMCEStart: start', event);
+      $$('body')[0].fire('celRTE:finishedInit', {
+        'editor' : editor
+      });
+      console.debug('celFinishTinyMCEStart: finish', event);
+    } catch (exp) {
+      console.error('celFinishTinyMCEStart failed', event, exp);
+    }
+  };
+
+  const lazyLoadTinyMCE = function(mceParentElem) {
+    try {
+      if (tinyConfigLoaded) {
+        getUninitializedMceEditors(mceParentElem).forEach(editorAreaId => {
+          console.debug('lazyLoadTinyMCE: mceAddEditor for editorArea', editorAreaId, mceParentElem);
+          tinymce.execCommand("mceAddEditor", false, editorAreaId);
+        });
+        console.debug('lazyLoadTinyMCE: finish', mceParentElem);
+      } else {
+        console.warn('lazyLoadTinyMCE: skipped, tinyConfig not yet loaded', mceParentElem);
+      }
+    } catch (exp) {
+      console.error("lazyLoadTinyMCE failed. ", exp);
+    }
+  };
+
+  var getUninitializedMceEditors = function(mceParentElem) {
+    console.log('getUninitializedMceEditors: start ', mceParentElem);
+    var mceEditorsToInit = new Array();
+    $(mceParentElem).select('textarea.mceEditor').each(function(editorArea) {
+      if (!editorArea.id) {
+        editorArea.writeAttribute('id', editorArea.name + 'Editor' + (++editorCounter));
+      }
+      var notInitialized = !tinymce.get(editorArea.id);
+      console.log('getUninitializedMceEditors: found new editorArea ', editorArea.id,
+          notInitialized);
+      if (notInitialized) {
+        mceEditorsToInit.push(editorArea.id);
+      }
+    });
+    console.log('getUninitializedMceEditors: returns ', mceParentElem, mceEditorsToInit);
+    return mceEditorsToInit;
+  };
+
+  var delayedEditorOpeningHandler = function(event) {
+    console.log('delayedEditorOpeningHandler: start ', event.memo);
+    var mceParentElem = event.memo.tabBodyId || "tabMenuPanel";
+    var mceEditorAreaAvailable = (getUninitializedMceEditors(mceParentElem).size() > 0);
+    if (mceEditorAreaAvailable) {
+      console.debug('delayedEditorOpeningHandler: stopping display event');
+      event.stop();
+      $$('body')[0].observe('celRTE:finishedInit', function() {
+        console.debug('delayedEditorOpeningHandler: start display effect');
+        event.memo.effect.start();
+      });
+    }
+  };
+  var initCelRTE4Listener = function() {
+    console.log('initCelRTE4Listener: before initCelRTE4');
+    initCelRTE4();
+  };
+
+  $j(document).ready(() => {
+    console.log("tinymce4: register document ready...");
+    $(document.body).observe('celements:contentChanged', event => lazyLoadTinyMCE(event.target));
+    if ($('tabMenuPanel')) {
+      $('tabMenuPanel').observe('tabedit:finishedLoadingDisplayNow',
+          delayedEditorOpeningHandler);
+      $('tabMenuPanel').observe('tabedit:tabLoadingFinished',
+          event => lazyLoadTinyMCE(event.memo.newTabBodyId));
+      console.log('loadTinyMCE-async on ready: before register initCelRTE4Listener');
+      getCelementsTabEditor().addAfterInitListener(initCelRTE4Listener);
+    }
+  });
+  
+})(window);

--- a/RichText-web-module/src/main/webapp/templates/celAjax/ImagePicker.vm
+++ b/RichText-web-module/src/main/webapp/templates/celAjax/ImagePicker.vm
@@ -1,0 +1,131 @@
+## init Celements variables
+$response.setStatus(200)
+##only include if legacy celements2web.xar is installed
+#if($xwiki.exists($services.model.resolveDocument('celements2web:Macros.initCelements')))
+$xwiki.includeForm("celements2web:Macros.initCelements", false)
+#end
+#set($isAjaxCall = ("$!request.ajax" == '1'))
+#if(!$isAjaxCall)
+## start a Celements Document
+#parse("celMacros/startCelementsDocument.vm")
+##
+#set($cel_loadAdminMenuBar=false)
+$celementsweb.includeCSSPage(':celRes/imagePicker.css')
+## start the celements body (and lacily finalise the header)
+#parse("celMacros/startCelementsBody.vm")
+##
+#end
+
+#set($imageOnly = "$!request.images")
+#if("$!imageOnly" == '')
+  #set($imageOnly = '1')
+#end
+<script language="javascript">
+var baseurl = '$!request.get('baseurl')';
+var imgurl = '$!request.get('imgurl')';
+var origFieldName = '$!request.get('origFieldName')';
+
+	function insertImage(filename) {
+		if (window.opener) {
+			window.opener.imagePickerCallback(filename, origFieldName);
+			self.close();
+		}
+	}
+
+  function clickOnFileAction(filename) {
+    insertImage(filename);
+    return false;
+  }
+
+	var preloadImg = new Image();
+
+    //------------------
+    // threadsafe asynchronous XMLHTTPRequest code
+    function executeCommand(url, callback) {
+        // we use a javascript feature here called "inner functions"
+        // using these means the local variables retain their values after the outer function
+        // has returned. this is useful for thread safety, so
+        // reassigning the onreadystatechange function doesn't stomp over earlier requests.
+        function ajaxBindCallback() {
+            if (ajaxRequest.readyState == 4) {
+                if (ajaxRequest.status == 200) {
+                    if (ajaxCallback) {
+                        ajaxCallback(ajaxRequest.responseText);
+                    } else {
+                        alert('no callback defined');
+                    }
+                } else {
+                    alert("There was a problem retrieving the xml data:\n" + ajaxRequest.status + ":\t" + ajaxRequest.statusText + "\n" + ajaxRequest.responseText);
+                }
+            }
+        }
+
+        // addMessage(url);
+        // use a local variable to hold our request and callback until the inner function is called...
+        var ajaxRequest = null;
+        var ajaxCallback = callback;
+
+        // bind our callback then hit the server...
+        if (window.XMLHttpRequest) {
+            // moz et al
+            ajaxRequest = new XMLHttpRequest();
+            ajaxRequest.onreadystatechange = ajaxBindCallback;
+            ajaxRequest.open("GET", url, true);
+            ajaxRequest.send(null);
+        } else if (window.ActiveXObject) {
+            // ie
+            ajaxRequest = new ActiveXObject("Microsoft.XMLHTTP");
+            if (ajaxRequest) {
+                ajaxRequest.onreadystatechange = ajaxBindCallback;
+                ajaxRequest.open("GET", url, true);
+                ajaxRequest.send();
+            }
+            else{
+                alert("your browser does not support xmlhttprequest" )
+            }
+        }
+        else{
+            alert("your browser does not support xmlhttprequest" )
+        }
+    }
+
+    function loadAttachmentList(baseurl) {
+        var url = baseurl + "?xpage=attachwysiwyg&images=$imageOnly";
+        executeCommand(url, loadAttachmentListCallback);
+    }
+
+    function loadAttachmentListCallback(e) {
+      var attachEl = document.getElementById("attachments");
+      attachEl.innerHTML = e;
+    }
+
+    function updateAttachName(form) {
+      form.xredirect.value=location;
+
+      var fname = form.filepath.value;
+      if (fname=="") {
+        return false;
+      }
+
+      var i = fname.lastIndexOf('\\');
+      if (i==-1)
+       i = fname.lastIndexOf('/');
+
+      fname = fname.substring(i+1);
+      if (form.filename.value==fname)
+       return true;
+
+      if (form.filename.value=="")
+       form.filename.value = fname;
+      return true;
+    }
+</script>
+<div id="attachments">
+
+</div>
+<script type="text/javascript">
+    loadAttachmentList(baseurl);
+</script>
+#if(!$isAjaxCall)
+#parse('celMacros/finaliseCelementsDocument.vm')
+#end

--- a/RichText-web-module/src/main/webapp/templates/celAjax/LinkPicker.vm
+++ b/RichText-web-module/src/main/webapp/templates/celAjax/LinkPicker.vm
@@ -1,0 +1,151 @@
+## init Celements variables
+$response.setStatus(200)
+##only include if legacy celements2web.xar is installed
+#if($xwiki.exists($services.model.resolveDocument('celements2web:Macros.initCelements')))
+$xwiki.includeForm("celements2web:Macros.initCelements", false)
+#end
+#set($isAjaxCall = ("$!request.ajax" == '1'))
+#if(!$isAjaxCall)
+## start a Celements Document
+#parse("celMacros/startCelementsDocument.vm")
+##
+#set($cel_loadAdminMenuBar=false)
+#set($HTMLBodyCSSClasses = "$!{HTMLBodyCSSClasses} celLinkPicker forceColors")
+## start the celements body (and lacily finalise the header)
+#parse("celMacros/startCelementsBody.vm")
+##
+#end
+
+##
+#macro(outputMenuItems $parentName)
+##macro: "$parentName", "$sp" <br />
+#foreach($item in $celementsweb.getSubNodesForParent("$!parentName", "$sp"))
+  #set($fullname = "$item.fullName")
+  #if($!mode == "FullName")
+    #set($value = $fullname)
+  #elseif($!mode == "Name")
+    #set($startAt = $fullname.indexOf('.') + 1)
+    #set($value = $fullname.substring($startAt, $fullname.length()))
+  #else
+    #set($value = $xwiki.getURL($fullname,'view'))
+  #end
+## check if getMenuName is overwritten
+#if("$!cel_linkpicker_MenuName_Macro" != '')
+#set($menuItemObj = $item)
+$xwiki.includeForm("$cel_linkpicker_MenuName_Macro", false)
+#else
+#set($menuName = $helpNav.getMultilingualMenuNameOnly($item.fullName, $language, false))
+#end
+#if("$!menuName" != '')
+  ## output xhtml
+  <div style="position:relative;left:15px;background-image:url($celementsweb.getSkinFile(':celRes/dotted_line.gif'));background-repeat:repeat-y;margin-top:5px;">
+  <div style="height:20px;vertical-align:middle;overflow:hidden">
+  <img src="$celementsweb.getSkinFile(':celRes/document.gif')" alt="Doc" style="margin-right:5px;"/>
+  <a href="$value" style="font:11px Arial;text-decoration:none;" ##
+  #if($isJSpicker)onclick="javascript:opener.document.forms.${form}['${field}'].value='$value';window.close();"#end ##
+  #if($isPickerMode)onclick="document.forms[0].${fieldname}.value = '$value'; return false;"#end>$!menuName</a><br />
+  </div>
+  ## second, third level
+#end
+#if($celementsweb.getSubNodesForParent("$!parentName", "$sp").size() > 0)
+#outputMenuItems("$item.fullName")
+#end
+#if("$!menuName" != '')
+  </div>
+#end
+#end ## foreach
+#end ## macros outputMenuItems
+##
+#set($helpNav = $celementsweb.createNavigation())
+## MAINPART
+## which space? default: Content
+#if($!context.getRequest().get("space") != "")
+ #set($space = "$!context.getRequest().get('space')")
+#elseif("$!cel_default_LinkPicker_space" != '')
+ #set($space = "$!{cel_default_LinkPicker_space}")
+#else
+ #set($space = "Content")
+#end
+## get parameters
+<div id="cel_linkPicker">
+#set($isPickerMode = ("$!request.picker" == '1') && ("$!request.fieldname" != ''))
+#if($isPickerMode)
+#set($fieldname = "$!request.fieldname")
+#end
+<div style="font:bold 11px Arial;margin:5px;">$adminMsg.get('cel_lpicker_name')</div>
+<div style="font:11px Arial;margin:5px;">$adminMsg.get('cel_lpicker_plzClickNotice')</div>
+##Bitte auf den Namen eines Dokumentes klicken um den entsprechenden Link auszuw&auml;hlen.
+#if($!context.getRequest().get("mode") != "")
+ #set($mode = $!context.getRequest().get("mode"))
+#else
+ #set($mode = "URL")
+#end
+#if($!context.getRequest().get("form") != "")
+ #set($form = $!context.getRequest().get("form"))
+#else
+ #if($debug)<div style="font:11px Arial;color:red;margin:5px;">Error: No form!</div>#end
+ #set($form = "")
+#end
+#if($!context.getRequest().get("field") != "")
+ #set($field = $!context.getRequest().get("field"))
+#else
+ #if($debug)<div style="font:11px Arial;color:red;margin:5px;">Error: No field!</div>#end
+ #set($field = "")
+#end
+#set($isJSpicker = (("$!{form}" != '') && ("$!{field}" != '')))
+##FIX use new celementsweb API to get MenuItems.
+## First Level Menu
+#foreach($sp in $space.split(','))
+<div style="font:bold 11px Arial;margin:5px;margin-top:20px;">$adminMsg.get('cel_lpicker_menuLinksTitle'): $sp</div>
+<div style="position:relative;left:15px;background-image:url($celementsweb.getSkinFile(':celRes/dotted_line.gif'));background-repeat:repeat-y;margin-top:5px;">
+#set($language = $xwiki.getSpacePreferenceFor('default_language', "$sp"))
+## use default-language because any menuItem must have a menuName
+## in the default language
+#outputMenuItems('')
+</div>
+#end
+<div style="font:bold 11px Arial;margin:5px;margin-top:20px;">$adminMsg.get('cel_lpicker_otherLinksTitle'):</div>
+#set($xwql = '')
+#foreach($sp in $space.split(','))
+  #if("$!sp" != '')
+    #if("$!xwql" == '')
+      #set ($xwql = "where doc.space = '$sp'")
+    #else
+      #set ($xwql = "$xwql or doc.space = '$sp'")
+    #end
+  #end
+#end
+#set($menu = [])
+<div style="position:relative;left:15px;background-image:url($celementsweb.getSkinFile(':celRes/dotted_line.gif'));background-repeat:repeat-y;margin-top:5px;">
+#foreach ($item in $services.query.xwql($xwql).execute())
+  #set($cur_doc = $xwiki.getDocument($item))
+  #set($menu_items = $cur_doc.getObjects("Celements2.MenuItem"))
+  #if(($menu_items.size() == 0) && ($cur_doc.getName() != "WebPreferences"))
+    #if($!mode == "FullName")
+      #set($value = $!cur_doc.getFullName())
+    #elseif($!mode == "Name")
+      #set($value = $!cur_doc.getName())
+    #else
+      #set($value = $!cur_doc.getURL('view'))
+    #end   
+    <div style="position:relative;left:15px;background-image:url($celementsweb.getSkinFile(':celRes/dotted_line.gif'));background-repeat:repeat-y;margin-top:5px;">
+    <div style="height:20px;vertical-align:middle;overflow:hidden">
+    <img src="$celementsweb.getSkinFile(':celRes/document.gif')" alt="Doc" style="margin-right:5px;"/>
+    <a href="$value" style="font:11px Arial;text-decoration:none;" ##
+    #if($isJSpicker)onclick="javascript:opener.document.forms.${form}['${field}'].value='$value';window.close();"#end ##
+    #if($isPickerMode)onclick="document.forms[0].${fieldname}.value = '$value'; return false;"#end>$!cur_doc.getFullName()</a><br />
+    </div>
+    #set($parentName = "$!cur_doc.getFullName()")
+    #set($sp = "$!cur_doc.getSpace()")
+##    show: $parentName : $celementsweb.getSubNodesForParent("$!parentName", "$sp").size()<br />
+    #if($celementsweb.getSubNodesForParent("$!parentName", "$sp").size() > 0)
+      #outputMenuItems($parentName)
+    #end
+    </div>
+  #end
+#end
+</div>
+</div>
+#if(!$isAjaxCall)
+#parse('celMacros/finaliseCelementsDocument.vm')
+#end

--- a/RichText-web-module/src/main/webapp/templates/celAjax/TinyConfig.vm
+++ b/RichText-web-module/src/main/webapp/templates/celAjax/TinyConfig.vm
@@ -1,0 +1,2 @@
+##delegate to celMacros/TinyConfig.vm to allow extending TinyConfig.vm
+#parse('celMacros/TinyConfig.vm')

--- a/RichText-web-module/src/main/webapp/templates/celAjax/tinyTemplateList.vm
+++ b/RichText-web-module/src/main/webapp/templates/celAjax/tinyTemplateList.vm
@@ -1,0 +1,14 @@
+// There templates will be displayed as a dropdown in all media dialog if the "template_external_list_url"
+// option is defined in TinyMCE init.
+
+#set($jsonBuilder = $services.celementsweb.getNewJSONBuilder())
+$jsonBuilder.openArray()##
+#foreach($templObj in $services.rteconfig.getRTETemplateList())
+$jsonBuilder.openArray()##
+$jsonBuilder.addString("$!{templObj.getProperty('templateName').getValue()}")##
+$jsonBuilder.addString("$!{templObj.getProperty('templateUrl').getValue()}")##
+$jsonBuilder.addString("$!{templObj.getProperty('templateDesc').getValue()}")##
+$jsonBuilder.closeArray()##
+#end
+$jsonBuilder.closeArray()##
+var tinyMCETemplateList = $!{jsonBuilder.getJSON()};

--- a/RichText-web-module/src/main/webapp/templates/celAjax/tinymce/Tiny4Config.vm
+++ b/RichText-web-module/src/main/webapp/templates/celAjax/tinymce/Tiny4Config.vm
@@ -1,0 +1,187 @@
+## ***********************************************************************
+## tinyMCE_width and tinyMCE_height set by PrepareVelocityContextService
+## ***********************************************************************
+$!services.rteconfig.setRteConfigHint("tinymce4")
+#set($rtePluginsPre = ["print","preview","searchreplace","autolink","directionality","visualblocks","visualchars","fullscreen","image","link","media","template","codesample","table","charmap","hr","pagebreak","nonbreaking","anchor","toc","insertdatetime","advlist","lists","textcolor","wordcount","imagetools","contextmenu","colorpicker","textpattern","help", "code", "paste"])
+#set($rtePluginsConfig = $services.rteconfig.getRTEConfigField('plugins'))
+## adding celements tinymce plugins
+#set($!dev = $rtePluginsPre.addAll(["celimage", "cellink"]))
+#set($rteOmitPlugins = [])
+#if("$!rtePluginsConfig" != '')
+  #foreach($oneRtePlugin in $rtePluginsConfig.split('[,| ]'))
+    #if($oneRtePlugin.startsWith('-'))
+      #set($!dev = $rteOmitPlugins.add($oneRtePlugin.replaceFirst('-','')))
+    #elseif("$!oneRtePlugin" != '')
+      #set($!dev = $rtePluginsPre.add($oneRtePlugin))
+    #end
+  #end
+#end
+#set($rtePlugins = '')
+  #foreach($oneRtePlugin in $rtePluginsPre)
+    #if(("$!oneRtePlugin" != '') && !$rteOmitPlugins.contains($oneRtePlugin))
+      #set($rtePlugins = "$!{rtePlugins} $!oneRtePlugin")
+    #end
+  #end
+#set($useCelCrop = ("$!xwiki.getSpacePreference('celcrop')" == '1'))
+#if($services.celementsphoto.useImageAnimations())
+  #set($galleriesXWQL = "from doc.object(XWiki.PhotoAlbumClass) as album")
+  #set($galleriesXWQL = "${galleriesXWQL} where doc.fullName <> 'XWiki.PhotoAlbumClassTemplate'")
+  #set($galleriesXWQL = "${galleriesXWQL} and doc.translation=0")
+  #set($galleriesXWQL = "${galleriesXWQL} order by doc.title, doc.name")
+  #set($availableGalleries = '')
+  #foreach($galleryFN in $services.query.xwql($galleriesXWQL).execute())
+    #set($galleryDoc = $xwiki.getDocument($galleryFN))
+    #set($galleryName = "$!galleryDoc.title ($!galleryDoc.name)")
+    #set($availableGalleries = "$!{availableGalleries},${galleryName}=${galleryFN}")
+  #end
+#end
+## lookup the rte valid elements in XWiki- and WebPreferences and
+## default back to the standard configuration
+#set($rte_valid_elements = $services.rteconfig.getRTEConfigField('valid_elements'))
+## lookup the rte invalid elements in XWiki- and WebPreferences and
+## default back to the standard configuration
+#set($rte_invalid_elements = $services.rteconfig.getRTEConfigField('invalid_elements'))
+## lookup the rte button layout in XWiki- and WebPreferences and
+## default back to the standard fields
+#set($rteRows = [])
+#foreach($rowNum in [1,2,3])
+  #set($rte_row = $services.rteconfig.getRTEConfigField("row_$!{rowNum}"))
+  #if("$!rte_row" != '')
+    #set($!devNull = $rteRows.add($rte_row))
+  #end
+#end
+## get other rte preferences
+#set($content_css_filenameURL = [ "$celementsweb.getSkinFile(':celRes/celements2-content.css', 'file')" ])
+#foreach($cssObj in $services.css.getRTEContentCSS())
+#if("$!{cssObj.getCSS()}" != '')
+    #set($!devNull = $content_css_filenameURL.add("$!{cssObj.getCSS()}"))
+  #end
+#end
+## file base link, file picker link
+#if(("$!xwiki.getSpacePreference('cel_centralfilebase')" != '') && ("$!xwiki.getSpacePreference('cel_centralfilebase')" != '-'))
+  #set($wiki_filbase_path = "$!xwiki.getSpacePreference('cel_centralfilebase')")
+#else
+  #set($wiki_filbase_path = "$doc.getFullName()")
+#end
+#set($attachmentPath = "$xwiki.getURL($wiki_filbase_path, 'view')")
+#set($attachmentDLPath = "$xwiki.getURL($wiki_filbase_path, 'download')")
+#if("$!imagePickerAttPath" != '')
+  #set($attachmentDLPath = $xwiki.getURL("$!imagePickerAttPath", 'download'))
+  #set($attachmentPath = $xwiki.getURL("$!imagePickerAttPath", 'view'))
+#end
+#set($linkPickerSpaces = "$!linkPickerSpaces") ## linkPickerSpaces could be undefined
+##FIXME move to blog-component after adding a linkPicker-api
+#set($blogPageDoc = $xwiki.celementsblog.getBlogPageByBlogSpace("$doc.space"))
+#if("$!blogPageDoc" != '')
+  #set($linkPickerSpaces = "$!blogPageDoc.space")
+#end
+##FIXME $linkPickerSpace must be given by input parameter depending on rte context
+#set($linkPickerSpace = "$doc.space")
+#set($filePickerSpace = "$linkPickerSpace") ## filePickerSpace must be a single space!!
+#if("$!linkPickerSpaces" != '')
+  #set($linkPickerSpace = "$!linkPickerSpaces")
+#end
+#set($parentSpace = "$!{xwiki.getSpacePreference('parent')}")
+#if(("$!parentSpace" != '') && ($linkPickerSpace.indexOf("$!{parentSpace}") < 0))
+  #set($linkPickerSpace = "$!linkPickerSpace,$!{parentSpace}")
+#end
+#set($fileUploadSpace = "$doc.space")
+#if("$!fileBaseUploadSpace" != '')
+  #set($fileUploadSpace = "$!fileBaseUploadSpace")
+#end
+#set($isSingle = '1')
+#if("$!fileBaseSingleDoc" != '')
+  #set($isSingle = "$fileBaseSingleDoc")
+#end
+#if("$!fileBasePickerSpace" != '')
+  #set($filePickerSpace = "$!fileBasePickerSpace")
+#end
+#set($filePickerDoc = $doc.getName())
+#if("$!singleAttachmentDocument" != '')
+  #set($filePickerDoc = "$!singleAttachmentDocument")
+#end
+##
+#*
+  ##this is wrong in general !!!
+  ##29.08.2014 FP: removed to fix problems for Programmzeitung!!!
+  #if($linkPickerSpace.indexOf('_') >= 0)
+    #set($linkPickerSpace = $linkPickerSpace.substring(0, $linkPickerSpace.indexOf('_')))
+  #end
+*#
+#set($allLinkPickerSpaces = "$!linkPickerSpace,$!services.rteconfig.getRTEConfigField('link_picker_spaces')")
+#set($allLinkPickerSpaces = $allLinkPickerSpaces.replaceAll(',,|^,|,$', ''))
+#set($fbDoc = "$!xwiki.getSpacePreference('cel_centralfilebase')")
+#if (("$!fbDoc" == '') && ("$!parentSpace" != ''))
+  #set($fbDoc = "$!xwiki.getSpacePreferenceFor('cel_centralfilebase', $parentSpace)")
+#end
+#if("$!fbDoc" == '')
+  #set($fbDoc = "${filePickerSpace}_filebase.AttachmentDocument")
+#elseif("$!fbDoc" == '-')
+  #set($fbDoc = "${filePickerSpace}.${filePickerDoc}")
+#end
+#set($hasUpload = '1') ## from where?
+#set($filebaseURL = "$doc.getURL('view')")
+#if("$!filebaseURL" == '')
+  #set($filebaseURL = "/WebHome")
+#end
+#set($filebaseURL = "$!{filebaseURL}?xpage=celements_ajax&ajax_mode=FileBase&picker=1")
+#set($filebaseURL = "$!{filebaseURL}&single_doc=${fbDoc}&fieldname=href")
+#set($filebaseURL = "$!{filebaseURL}&src_doc=${filePickerSpace}.${filePickerDoc}&columns=10")
+#set($filebaseURL = "$!{filebaseURL}&root=${filePickerSpace}&hasUpload=$hasUpload")
+##
+## start writing JSON
+#set($jsonBuilder = $services.json.newBuilder())##
+$jsonBuilder.openDictionary()##
+$jsonBuilder.addProperty("selector", "textarea.tinyMCE,textarea.mceEditor")##
+$jsonBuilder.addProperty("language", "$!admin_language")##
+$jsonBuilder.addProperty("valid_elements", "$!rte_valid_elements")##
+$jsonBuilder.addProperty("invalid_elements", "$!rte_invalid_elements")##
+$jsonBuilder.addProperty("theme", "modern")##
+$jsonBuilder.addProperty("height", "$!tinyMCE_height")##
+$jsonBuilder.addProperty("width", "$!tinyMCE_width")##
+$jsonBuilder.addProperty("menubar", false)##
+$jsonBuilder.addProperty("branding", false)##
+$jsonBuilder.addProperty("plugins", "$!rtePlugins")##
+$jsonBuilder.openProperty("external_plugins")##
+$jsonBuilder.openDictionary()##
+$jsonBuilder.addProperty("celimage", $services.celementsweb.getSkinFile(':celRTE/4.9.11/plugins/celimage/editor_plugin_src.js', 'file'))##
+$jsonBuilder.addProperty("cellink", $services.celementsweb.getSkinFile(':celRTE/4.9.11/plugins/cellink/editor_plugin_src.js', 'file'))##
+$jsonBuilder.closeDictionary()## external plugins
+$jsonBuilder.openArray("toolbar")##
+#foreach($rteRowLayout in $rteRows)
+  $jsonBuilder.addValue($rteRowLayout)
+#end
+$jsonBuilder.closeArray()##
+$jsonBuilder.addProperty("celanim_slideshow",  $!services.celementsphoto.useImageAnimations())##
+$jsonBuilder.addProperty("cel_crop",  $!useCelCrop)##
+#if($services.celementsphoto.useImageAnimations())
+  $jsonBuilder.addProperty("gallerylist", "$availableGalleries.replaceFirst(',','')")##
+#end
+$jsonBuilder.openArray("content_css")##
+#foreach($cssURL in $content_css_filenameURL)
+  $jsonBuilder.addValue($cssURL)
+#end
+$jsonBuilder.closeArray()##
+## file base link, file picker link
+$jsonBuilder.addProperty("wiki_images_path", "$xwiki.getURL($wiki_filbase_path, 'download')")##
+$jsonBuilder.addProperty("wiki_attach_path", "$attachmentPath")##
+$jsonBuilder.addProperty("wiki_imagedownload_path", "$attachmentDLPath")##
+$jsonBuilder.addProperty("wiki_linkpicker_space", "$allLinkPickerSpaces")##
+$jsonBuilder.addProperty("wiki_linkpicker_baseurl", "$doc.getURL('view')")##
+$jsonBuilder.addProperty("wiki_filepicker_upload_space", "$fileUploadSpace")##
+$jsonBuilder.addProperty("wiki_filepicker_space", "$filePickerSpace")##
+$jsonBuilder.addProperty("wiki_filepicker_doc", "$filePickerDoc")##
+$jsonBuilder.addProperty("wiki_filebase_link", "$!{filebaseURL}")##
+$jsonBuilder.addProperty("wiki_filebase_single_doc", "$isSingle")##
+$jsonBuilder.addProperty("entity_encoding", "raw")##
+$jsonBuilder.addProperty("autoresize_bottom_margin", 1)##
+$jsonBuilder.addProperty("autoresize_min_height", 0)##
+$jsonBuilder.openProperty("style_formats")##
+$jsonBuilder.addValue($services.rteconfig.getRteJsonConfigField("style_formats"))##
+$jsonBuilder.closeDictionary()## tiny4 config dictionary
+$jsonBuilder.getJSON()
+##        image_advtab: true,
+##        templates: [
+##          { title: 'Test template 1', content: 'Test 1' },
+##          { title: 'Test template 2', content: 'Test 2' }
+##        ],

--- a/RichText-web-module/src/main/webapp/templates/celMacros/TinyConfig.vm
+++ b/RichText-web-module/src/main/webapp/templates/celMacros/TinyConfig.vm
@@ -1,0 +1,301 @@
+#if("$!celNewButtons" == '')
+#set($celNewButtons = $services.celementsweb.useNewButtons())
+#end
+#if("$!tinyMCE_statuslocation" == '')
+  #set($tinyMCE_statuslocation = 'bottom')
+#end
+#if("$!tinyMCE_height" == '')
+  #set($tinyMCE_height = 500)
+#end
+#if("$!tinyMCE_width" == '')
+  #set($tinyMCE_width = 453)
+#end
+#set($xwikiPref_template_url = "$!xwiki.getDocument('XWiki.XWikiPreferences').getAttachment('template-list.js')")
+#set($webPref_template_url = "$!xwiki.getDocument('${doc.space}.WebPreferences').getAttachment('template-list.js')")
+#if(!$services.rteconfig.getRTETemplateList().isEmpty())
+  #set($template_external_list_url = $doc.getURL($context.action, 'xpage=celements_ajax&ajax_mode=tinyTemplateList'))
+#elseif ("$!webPref_template_url" != '')
+  #set($template_external_list_url = $!services.celementsweb.getSkinFile("${doc.space}.WebPreferences;template-list.js", 'file'))
+#elseif ("$!xwikiPref_template_url" != '')
+  #set($template_external_list_url = $!services.celementsweb.getSkinFile('XWiki.XWikiPreferences;template-list.js', 'file'))
+#else
+  #set($template_external_list_url = $!services.celementsweb.getSkinFile("$services.model.serialize($skin_doc.documentReference, 'default');template-list.js", 'file'))
+#end
+{ 
+  "mode" : "specific_textareas",
+  "editor_selector" : "mceEditor",
+  "editor_deselector" : "mceNoEditor",
+#set($pageStyles = '')
+#if("$!{xwiki.celementsweb.getPageLayoutForDoc($doc.documentReference)}" != '')
+#set($pageStyles = "layout_$!{xwiki.celementsweb.getPageLayoutForDoc($doc.documentReference)}")
+#end
+##TODO get pageStyles from pageType-scriptService
+#set($cel_pageTypeObj = $doc.getObject('Celements2.PageType', true))
+#set($pageStyles = "$!{pageStyles} $!cel_pageTypeObj.getProperty('page_styles').getValue()")
+  "body_class" : "$!{pageStyles.trim()}",
+  "language" : "$admin_language",
+  "theme" : "advanced",
+  "editor_css" : "$services.celementsweb.getSkinFile(':celRTE/celements-ui.css')",
+  ## lookup the additional rte_plugins field in the XWiki and WebPreference
+  #set($rtePluginsConfig = $services.rteconfig.getRTEConfigField('plugins'))
+  ##FP 16.11.2012; remove "autoresize" from rtePluginsPre because there are issues
+  #set($rtePluginsPre = ["safari","save","paste","advlink","template","table","lists","inlinepopups","advimage","contextmenu","celimage"])
+  #set($rteOmitPlugins = [])
+  #if("$!rtePluginsConfig" != '')
+    #foreach($oneRtePlugin in $rtePluginsConfig.split('[,| ]'))
+      #if($oneRtePlugin.startsWith('-'))
+        #set($!dev = $rteOmitPlugins.add($oneRtePlugin.replaceFirst('-','')))
+      #elseif("$!oneRtePlugin" != '')
+        #set($!dev = $rtePluginsPre.add($oneRtePlugin))
+      #end
+    #end
+  #end
+  #set($rtePlugins = '')
+    #foreach($oneRtePlugin in $rtePluginsPre)
+      #if(("$!oneRtePlugin" != '') && !$rteOmitPlugins.contains($oneRtePlugin))
+        #set($rtePlugins = "$!{rtePlugins},$!oneRtePlugin")
+      #end
+    #end
+  "plugins" : "${rtePlugins}",
+  "save_enablewhendirty" : false,
+  "save_onsavecallback" : "simplySave",
+  "save_cancelFunction" : "cancelAndClose",
+  "theme_advanced_layout_manager" : "SimpleLayout",
+  "theme_advanced_toolbar_location" : "top",
+  "theme_advanced_toolbar_align" : "left",
+  "height" : "$tinyMCE_height",
+  "width" : "$tinyMCE_width",
+  "template_external_list_url" : "$!template_external_list_url",
+  "theme_advanced_statusbar_location" : "$tinyMCE_statuslocation",
+  "theme_advanced_resize_horizontal" : false,
+  "theme_advanced_resizing" : true,
+  "apply_source_formatting" : true,
+  "advimage_constrain_proportions" : true,
+  "relative_urls" : false,
+  "document_base_url" : "/",
+  "inline_styles" : true,
+  "accessibility_warnings" : false,
+  #set($content_css_filenameURL = "$celementsweb.getSkinFile(':celRes/celements2-content.css', 'file')")
+  #foreach($cssObj in $services.css.getRTEContentCSS())
+  #if("$!{cssObj.getCSS()}" != '')
+      #set($content_css_filenameURL = "$!{content_css_filenameURL},$!{cssObj.getCSS()}")
+    #end
+  #end
+  #if("$!content_css_filenameURL" != '')
+  "content_css" : "$!{content_css_filenameURL.replaceAll('^,', '')}",
+  #end
+  ## lookup the rte_styles field in the XWiki and WebPreference
+  #set($rteStyles = $services.rteconfig.getRTEConfigField('styles'))
+##  #if("$!rteStyles" == '')
+##    ## default back to the standard fields.
+##    #set($rteStyles = 'cel_rte_style_titel=h1;cel_rte_style_untertitel=h2;cel_rte_style_text=text')
+##  #end
+  ## get multilingual style names
+  #set($mlRteStyle = '')
+  #set($mlRteStyleName = '')
+  #foreach($rteStyleElement in $rteStyles.split('[=;]'))
+    #if($velocityCount%2 == 1)
+      #set($mlRteStyleName = $adminMsg.get("$rteStyleElement"))
+    #elseif("$mlRteStyleName" != '')
+      #set($mlRteStyle = "${mlRteStyle}${mlRteStyleName}=${rteStyleElement};")
+      #set($mlRteStyleName = '')
+    #end
+  #end
+  ## lookup the rte button layout in XWiki- and WebPreferences and
+  ## default back to the standard fields
+  #set($rte_row_1 = $services.rteconfig.getRTEConfigField('row_1'))
+  #if("$!rte_row_1" == '')
+    #if(!$celNewButtons)
+      #set($rte_row_1 = "$!{rte_row_1}save,cancel,|,")
+    #end
+    #set($rte_row_1 = "$!{rte_row_1}bold,italic,underline,|,")
+    #set($rte_row_1 = "$!{rte_row_1}justifyleft,justifycenter,justifyright,justifyfull,")
+    #set($rte_row_1 = "$!{rte_row_1}|,bullist,numlist,|,link,unlink,")
+    #set($rte_row_1 = "$!{rte_row_1}image,forecolor,backcolor,|,code")
+  #elseif("$!rte_row_1" == 'none')
+    #set($rte_row_1 = '')
+  #end
+  #set($rte_row_2 = $services.rteconfig.getRTEConfigField('row_2'))
+  #if("$!rte_row_2" == '')
+    #set($rte_row_2 = 'styleselect,fontselect,fontsizeselect,pastetext,pasteword')
+  #elseif("$!rte_row_2" == 'none')
+    #set($rte_row_2 = '')
+  #end
+  #set($rte_row_3 = $services.rteconfig.getRTEConfigField('row_3')) 
+  #if("$!rte_row_3" == '')
+    #set($rte_row_3 = 'tablecontrols')
+  #elseif("$!rte_row_3" == 'none')
+    #set($rte_row_3 = '')
+  #end
+  #if($rte_supress_cancel)
+    #set($rte_row_1 = "$!{rte_row_1.replaceAll('cancel,?(\|,|separator,)?','')}")
+    #set($rte_row_2 = "$!{rte_row_2.replaceAll('cancel,?(\|,|separator,)?','')}")
+    #set($rte_row_3 = "$!{rte_row_3.replaceAll('cancel,?(\|,|separator,)?','')}")
+  #end
+  #if($rte_supress_save)
+    #set($rte_row_1 = "$!{rte_row_1.replaceAll('save,?(\|,|separator,)?','')}")
+    #set($rte_row_2 = "$!{rte_row_2.replaceAll('save,?(\|,|separator,)?','')}")
+    #set($rte_row_3 = "$!{rte_row_3.replaceAll('save,?(\|,|separator,)?','')}")
+  #end
+  ## get other rte preferences
+  #set($rte_cancel_option = "$!userObj.getProperty('rte_cancel_option').getValue()")
+  #if("$!rte_cancel_option" == '') 
+    #set($rte_cancel_option = 'ask')
+  #end
+  "theme_advanced_styles" : "$!mlRteStyle.replaceAll(';$','')",
+  "theme_advanced_buttons1" : "$rte_row_1",
+  "theme_advanced_buttons2" : "$rte_row_2",
+  "theme_advanced_buttons3" : "$rte_row_3",
+  #set($rte_blockformats = $services.rteconfig.getRTEConfigField('blockformats'))
+  ## get multilingual blockformat names
+  #set($mlBlockFormat = '')
+  #set($mlBlockFormatName = '')
+  #foreach($blockFormatElement in $rte_blockformats.split('[=,]'))
+    #if($velocityCount%2 == 1)
+      #set($mlBlockFormatName = $adminMsg.get("$blockFormatElement"))
+    #elseif("$mlBlockFormatName" != '')
+      #set($mlBlockFormat = "${mlBlockFormat}${mlBlockFormatName}=${blockFormatElement},")
+      #set($mlBlockFormatName = '')
+    #end
+  #end
+  "theme_advanced_blockformats" : "$!mlBlockFormat.replaceAll(',$','')",
+  ## lookup the rte valid elements in XWiki- and WebPreferences and
+  ## default back to the standard configuration
+  ##TODO move to API-Call for better control on defaults.
+  #set($rte_valid_elements = $services.rteconfig.getRTEConfigField('valid_elements'))
+  #if("$!rte_valid_elements" == '')
+    #set($rte_valid_elements = "$!{rte_valid_elements}+a[href|class|target|onclick|name|id|title|rel|hreflang],b/strong,br,")
+    #set($rte_valid_elements = "$!{rte_valid_elements}caption,#h?[align<center?justify?left?right|class|style|id],")
+    #set($rte_valid_elements = "$!{rte_valid_elements}hr[class|width|size|noshade],")
+    #set($rte_valid_elements = "$!{rte_valid_elements}img[width|height|class|align|style|src|border=0|alt|id|title|usemap],")
+    #set($rte_valid_elements = "$!{rte_valid_elements}i/em,#p[style|class|name|id],-span[class|style|id|title],")
+    #set($rte_valid_elements = "$!{rte_valid_elements}textformat[blockindent|indent|leading|leftmargin|rightmargin|tabstops],")
+    #set($rte_valid_elements = "$!{rte_valid_elements}sub[class],sup[class],")
+    #set($rte_valid_elements = "$!{rte_valid_elements}table[align<center?left?right|bgcolor|border|cellpadding|cellspacing|class|height|width|style|id|title],")
+    #set($rte_valid_elements = "$!{rte_valid_elements}tbody[align<center?char?justify?left?right|class|valign<baseline?bottom?middle?top],")
+    #set($rte_valid_elements = "$!{rte_valid_elements}#td[align<center?char?justify?left?right|bgcolor|class|colspan|headers|height|nowrap<nowrap|style|rowspan|scope<col?colgroup?row?rowgroup|valign<baseline?bottom?middle?top|width],")
+    #set($rte_valid_elements = "$!{rte_valid_elements}#th[align<center?char?justify?left?right|bgcolor|class|colspan|headers|height|rowspan|scope<col?colgroup?row?rowgroup|valign<baseline?bottom?middle?top|style|width],")
+    #set($rte_valid_elements = "$!{rte_valid_elements}thead[align<center?char?justify?left?right|class|valign<baseline?bottom?middle?top],")
+    #set($rte_valid_elements = "$!{rte_valid_elements}-tr[align<center?char?justify?left?right|bgcolor|class|style|rowspan|valign<baseline?bottom?middle?top|id],")
+    #set($rte_valid_elements = "$!{rte_valid_elements}-ol[class|type|compact],-ul[class|type|compact],#li[class]")
+  #end
+  "valid_elements" : "$rte_valid_elements",
+  ## lookup the rte invalid elements in XWiki- and WebPreferences and
+  ## default back to the standard configuration
+  ##TODO move to API-Call for better control on defaults.
+  #set($rte_invalid_elements = $services.rteconfig.getRTEConfigField('invalid_elements'))
+  #if("$!rte_invalid_elements" == '')
+    #set($rte_invalid_elements = "$!{rte_invalid_elements}abbr,acronym,address,applet,area,base,basefont,bdo,big,")
+    #set($rte_invalid_elements = "$!{rte_invalid_elements}blockquote,body,button,center,cite,code,col,colgroup,")
+    #set($rte_invalid_elements = "$!{rte_invalid_elements}dd,del,dfn,dir,div,dl,dt,fieldset,font,form,frame,")
+    #set($rte_invalid_elements = "$!{rte_invalid_elements}frameset,head,html,iframe,input,ins,isindex,")
+    #set($rte_invalid_elements = "$!{rte_invalid_elements}kbd,label,legend,link,map,menu,meta,noframes,noscript,")
+    #set($rte_invalid_elements = "$!{rte_invalid_elements}object,optgroup,option,param,pre/listing/plaintext/xmp,")
+    #set($rte_invalid_elements = "$!{rte_invalid_elements}q,s,samp,script,select,small,strike,textarea,tfoot,")
+    #set($rte_invalid_elements = "$!{rte_invalid_elements}tt,u,var")
+  #end
+  "invalid_elements" : "$rte_invalid_elements",
+  ##
+  #set($spellCheckTest = ",$!{rtePlugins},")
+  #if($spellCheckTest.contains(',spellchecker,'))
+    "spellchecker_languages" : "+English=en-us,French=fr,German=de,Italian=it",
+    "spellchecker_rpc_url" : "/jmyspell-spellchecker",
+  #end
+  "celanim_slideshow" : $!celementsweb.useImageAnimations(),
+  #set($useCelCrop = ("$!xwiki.getSpacePreference('celcrop')" == '1'))
+  "cel_crop" : $useCelCrop,
+  #if($celementsweb.useImageAnimations())
+    #set($galleriesXWQL = "from doc.object(XWiki.PhotoAlbumClass) as album")
+    #set($galleriesXWQL = "${galleriesXWQL} where doc.fullName <> 'XWiki.PhotoAlbumClassTemplate'")
+    #set($galleriesXWQL = "${galleriesXWQL} and doc.translation=0")
+    #set($galleriesXWQL = "${galleriesXWQL} order by doc.title, doc.name")
+    #set($availableGalleries = '')
+    #foreach($galleryFN in $services.query.xwql($galleriesXWQL).execute())
+      #set($galleryDoc = $xwiki.getDocument($galleryFN))
+      #set($galleryName = "$!galleryDoc.title ($!galleryDoc.name)")
+      #set($availableGalleries = "$!{availableGalleries},${galleryName}=${galleryFN}")
+    #end
+    "gallerylist" : "$availableGalleries.replaceFirst(',','')",
+  #end
+  ##
+  ## file base link, file picker link
+  #if(("$!xwiki.getSpacePreference('cel_centralfilebase')" != '') && ("$!xwiki.getSpacePreference('cel_centralfilebase')" != '-'))
+    #set($wiki_filbase_path = "$!xwiki.getSpacePreference('cel_centralfilebase')")
+  #else
+    #set($wiki_filbase_path = "$doc.getFullName()")
+  #end
+  "wiki_images_path" : "$xwiki.getURL($wiki_filbase_path, 'download')",
+  #set($attachmentPath = "$xwiki.getURL($wiki_filbase_path, 'view')")
+  #set($attachmentDLPath = "$xwiki.getURL($wiki_filbase_path, 'download')")
+  #if("$!imagePickerAttPath" != '')
+    #set($attachmentDLPath = $xwiki.getURL("$!imagePickerAttPath", 'download'))
+    #set($attachmentPath = $xwiki.getURL("$!imagePickerAttPath", 'view'))
+  #end
+  "wiki_attach_path" : "$attachmentPath",
+  "wiki_imagedownload_path" : "$attachmentDLPath",
+  #set($linkPickerSpaces = "$!linkPickerSpaces") ## linkPickerSpaces could be undefined
+  ##FIXME move to blog-component after adding a linkPicker-api
+  #set($blogPageDoc = $xwiki.celementsblog.getBlogPageByBlogSpace("$doc.space"))
+  #if("$!blogPageDoc" != '')
+    #set($linkPickerSpaces = "$!blogPageDoc.space")
+  #end
+  ##FIXME $linkPickerSpace must be given by input parameter depending on rte context
+  #set($linkPickerSpace = "$doc.space")
+  #set($filePickerSpace = "$linkPickerSpace") ## filePickerSpace must be a single space!!
+  #if("$!linkPickerSpaces" != '')
+    #set($linkPickerSpace = "$!linkPickerSpaces")
+  #end
+  #set($parentSpace = "$!{xwiki.getSpacePreference('parent')}")
+  #if(("$!parentSpace" != '') && ($linkPickerSpace.indexOf("$!{parentSpace}") < 0))
+    #set($linkPickerSpace = "$!linkPickerSpace,$!{parentSpace}")
+  #end
+  #set($fileUploadSpace = "$doc.space")
+  #if("$!fileBaseUploadSpace" != '')
+    #set($fileUploadSpace = "$!fileBaseUploadSpace")
+  #end
+  #set($isSingle = '1')
+  #if("$!fileBaseSingleDoc" != '')
+    #set($isSingle = "$fileBaseSingleDoc")
+  #end
+  #if("$!fileBasePickerSpace" != '')
+    #set($filePickerSpace = "$!fileBasePickerSpace")
+  #end
+  #set($filePickerDoc = $doc.getName())
+  #if("$!singleAttachmentDocument" != '')
+    #set($filePickerDoc = "$!singleAttachmentDocument")
+  #end
+#*
+  ##this is wrong in general !!!
+  ##29.08.2014 FP: removed to fix problems for Programmzeitung!!!
+  #if($linkPickerSpace.indexOf('_') >= 0)
+    #set($linkPickerSpace = $linkPickerSpace.substring(0, $linkPickerSpace.indexOf('_')))
+  #end
+*#
+  #set($allLinkPickerSpaces = "$!linkPickerSpace,$!services.rteconfig.getRTEConfigField('link_picker_spaces')")
+  #set($allLinkPickerSpaces = $allLinkPickerSpaces.replaceAll(',,|^,|,$', ''))
+  "wiki_linkpicker_space" : "$allLinkPickerSpaces",
+  "wiki_linkpicker_baseurl" : "$doc.getURL('view')",
+  "wiki_filepicker_upload_space" : "$fileUploadSpace",
+  "wiki_filepicker_space" : "$filePickerSpace",
+  "wiki_filepicker_doc" : "$filePickerDoc",
+  #set($fbDoc = "$!xwiki.getSpacePreference('cel_centralfilebase')")
+  #if (("$!fbDoc" == '') && ("$!parentSpace" != ''))
+    #set($fbDoc = "$!xwiki.getSpacePreferenceFor('cel_centralfilebase', $parentSpace)")
+  #end
+  #if("$!fbDoc" == '')
+    #set($fbDoc = "${filePickerSpace}_filebase.AttachmentDocument")
+  #elseif("$!fbDoc" == '-')
+    #set($fbDoc = "${filePickerSpace}.${filePickerDoc}")
+  #end
+  #set($hasUpload = '1') ## from where?
+  #set($filebaseURL = "$doc.getURL('view')")
+  #if("$!filebaseURL" == '')
+    #set($filebaseURL = "/WebHome")
+  #end
+  #set($filebaseURL = "$!{filebaseURL}?xpage=celements_ajax&ajax_mode=FileBase&picker=1")
+  #set($filebaseURL = "$!{filebaseURL}&single_doc=${fbDoc}&fieldname=href")
+  #set($filebaseURL = "$!{filebaseURL}&src_doc=${filePickerSpace}.${filePickerDoc}&columns=10")
+  #set($filebaseURL = "$!{filebaseURL}&root=${filePickerSpace}&hasUpload=$hasUpload")
+  "wiki_filebase_link" : "$!{filebaseURL}",
+  "wiki_filebase_single_doc" : "$isSingle" ##
+}

--- a/RichText-web-module/src/main/webapp/templates/celMacros/loadRTE.vm
+++ b/RichText-web-module/src/main/webapp/templates/celMacros/loadRTE.vm
@@ -1,0 +1,89 @@
+## loadRTE
+## INPUT: $page_type, $type_props, $content_css_filename
+## INPUT (optional): $content_css_filenameURL (default: computed from $content_css_filename)
+## INPUT (optional): $tinyMCE_height (default 500), $tinyMCE_width (default 453)
+##
+## @deprecated since 2.18.0 please use celAjax/TinyConfig.vm instead
+##
+## should we load the rte?
+#set($type = $page_type)
+## get the specific edit template
+#set($load_rte = ($!type_props.getProperty("load_richtext").getValue() == 1))
+##
+#if($hasedit && $context.getAction()=="edit" && ($!doc.getObjects('Celements2.PageType').size() == 0 || $load_rte))
+#set($ptype_rte_height = $type_props.getProperty('rte_height').getValue())
+#set($ptype_rte_width = $type_props.getProperty('rte_width').getValue())
+#if("$!ptype_rte_height" != '')
+  #set($tinyMCE_height = $ptype_rte_height)
+#end
+#if("$!ptype_rte_width" != '')
+  #set($tinyMCE_width = $ptype_rte_width)
+#end
+#if("$!tinyMCE_height" == '')
+  #set($tinyMCE_height = 500)
+#end
+#if("$!tinyMCE_width" == '')
+  #set($tinyMCE_width = 453)
+#end
+<script language="javascript" type="text/javascript" src="${request.contextPath}/tiny_mce/tiny_mce_src.js"></script>
+<script language="javascript" type="text/javascript">
+tinyMCE.init({
+  mode : "textareas",
+  theme : "advanced",
+  save_enablewhendirty : true,
+  plugins : "table,save,cancel,advlink",
+  theme_advanced_layout_manager: "SimpleLayout",
+  theme_advanced_toolbar_location : "top",
+  theme_advanced_toolbar_align : "left",
+  height: "$tinyMCE_height",
+  width: "$tinyMCE_width",
+  #if($skin_doc.getAttachment("$!content_css_filename"))
+  #set($content_css_filenameURL = "$!{content_css_filenameURL},$skin_doc.getAttachmentURL($!content_css_filename,'download')")
+  #end
+  #foreach($cssObj in $xwiki.celementsweb.getRTEContentCSS())
+    #if("$!{cssObj.getCSS()}" != '')
+      #set($content_css_filenameURL = "$!{content_css_filenameURL},$!{cssObj.getCSS()}")
+    #end
+  #end
+  #if("$!content_css_filenameURL" != '')
+  content_css : "$!{content_css_filenameURL.replaceAll('^,', '')}",
+  #end
+  ## lookup the rte_styles field in the XWiki and WebPreference
+  #set($rteStyles = "$!xwiki.getSpacePreference('rte_styles')")
+  #if("$!rteStyles" == '')
+  	## default back to the standard fields.
+    #set($rteStyles = 'Titel=h1;Untertitel=h2;Text=text')
+  #end
+  theme_advanced_styles : "$!rteStyles",
+  // disable and re-enable everyting in order to get a customized layout
+  theme_advanced_disable : "bold,italic,strikethrough,anchor,help,underline,separator,justifyleft,justifycenter,justifyright,justifyfull,separator,bullist,numlist,separator,outdent,indent,separator,link,unlink,image,fontselect,fontsizeselect,separator,forecolor,backcolor,separator,charmap,hr,separator,undo,redo,removeformat,visualaid,cleanup,code,sub,sup,styleselect,formatselect",
+  theme_advanced_buttons1_add : "save,cancel,separator,bold,italic,underline,separator,justifyleft,justifycenter,justifyright,justifyfull,separator,bullist,numlist,separator,link,unlink,image,forecolor,backcolor,separator,code",
+  theme_advanced_buttons2_add : "styleselect,fontselect,fontsizeselect",
+  theme_advanced_buttons3_add : "tablecontrols",
+##
+  extended_valid_elements : "a[name|href|target|title|onclick],img[class|src|border=0|alt|title|hspace|vspace|width|height|align|onmouseover|onmouseout|name],hr[class|width|size|noshade],font[face|size|color|style],span[class|align|style]",
+  wiki_images_path : "$xwiki.getURL($doc.getFullName(), 'download')",
+  #set($attachmentPath = "$xwiki.getURL($doc.getFullName(), 'view')")
+  #set($attachmentDLPath = "$xwiki.getURL($doc.getFullName(), 'download')")
+  #if("$!imagePickerAttPath" != '')
+    #set($attachmentDLPath = $xwiki.getURL("$!imagePickerAttPath", 'download'))
+    #set($attachmentPath = $xwiki.getURL("$!imagePickerAttPath", 'view'))
+  #end
+  wiki_attach_path : "$attachmentPath",
+  wiki_imagedownload_path : "$attachmentDLPath",
+  plugin_cancel_cancelFunction : "tiny_mce_cancel"
+});
+##
+function tiny_mce_cancel(){
+if(document.forms.edit){
+  document.forms.edit.action = "$doc.getURL('cancel')";
+  if(doBeforeCancelSubmit) {
+    doBeforeCancelSubmit();
+  }
+  document.forms.edit.submit();
+} else {
+  alert("Error: no edit form!");
+}
+}
+</script>
+#end


### PR DESCRIPTION
https://synjira.atlassian.net/browse/CELDEV-1076

move TinyConfig.vm, Tiny4Config.vm and Link-/File- and ImagePicker templates and tinyMce plugins from celements-web and celements-structuredDataEditor-web to RichText-web-module